### PR TITLE
Add Infoblox DHCP Prerequisites Checker & Fixer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CONFIG  ?= config/environment.yml
 TF_DIR  ?= terraform
 TF_VARS ?= -var="config_file=../$(CONFIG)" -var-file="secret.tfvars"
 
-.PHONY: help login vault-start vault-stop vault-status vault-setup init validate plan apply destroy redeploy output status progress logs creds
+.PHONY: help login vault-start vault-stop vault-status vault-setup init validate plan apply destroy redeploy output status progress logs creds check-prereqs fix-prereqs
 
 help:
 	@echo "Targets:"
@@ -29,8 +29,13 @@ help:
 	@echo "  make logs PHASE=x HOST=y RUN=N   - show run N"
 	@echo "  make creds           - list all VM credential Vault paths"
 	@echo "  make creds HOST=name - show credentials for a specific VM"
+	@echo "  make check-prereqs HOST=name   - check Infoblox DHCP prerequisites on a host"
+	@echo "  make fix-prereqs HOST=name     - check and fix prerequisites on a host"
 
-AWS_PROFILE ?= $(shell python3 -c "import yaml; print(yaml.safe_load(open('$(CONFIG)'))['aws']['profile'])" 2>/dev/null || echo "dibya-aws")
+# Helper: extract a field from a YAML section using awk (no pyyaml dependency).
+_yaml_field = $(shell awk -v sec="$(1)" -v key="$(2)" '$$0 ~ "^"sec":" { in_sec=1; next } in_sec && /^[^[:space:]]/ { in_sec=0 } in_sec && $$1 == key":" { $$1=""; sub(/^[[:space:]]+/, ""); gsub(/["'"'"']/, ""); print; exit }' $(CONFIG))
+
+AWS_PROFILE ?= $(or $(call _yaml_field,aws,profile),dibya-aws)
 
 login:
 	aws sso login --profile $(AWS_PROFILE)
@@ -110,3 +115,59 @@ creds:
 			python3 -c "import sys,json; d=json.load(sys.stdin)['data']['data']; [print(f'{k}: {v}') for k,v in d.items()]" || \
 			echo "Not found. Ensure apply ran with key_pair_pem_path set and HOST=$(HOST) exists."; \
 	fi
+
+AWS_REGION      ?= $(call _yaml_field,aws,region)
+
+_require_host:
+	@if [ -z "$(HOST)" ]; then echo "ERROR: HOST is required. Usage: make $@ HOST=client01"; exit 1; fi
+
+_resolve_instance_id:
+	$(eval INSTANCE_ID := $(shell terraform -chdir=$(TF_DIR) output -json host_inventory 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('$(HOST)',{}).get('instance_id',''))" 2>/dev/null))
+	@if [ -z "$(INSTANCE_ID)" ]; then echo "ERROR: Could not resolve instance ID for HOST=$(HOST). Run 'make apply' first."; exit 1; fi
+
+
+# ---------------------------------------------------------------------------
+# Prerequisite checker: run check-prerequisites.ps1 on a host via SSM.
+# Usage: make check-prereqs HOST=dhcp01
+#        make fix-prereqs   HOST=client01
+# Auto-detects role from Terraform host_inventory.
+# ---------------------------------------------------------------------------
+
+DOMAIN_FQDN ?= $(call _yaml_field,domain,fqdn)
+SVC_USER    ?= $(call _yaml_field,credentials,service_user)
+
+_resolve_role = $(eval HOST_ROLE := $(shell terraform -chdir=$(TF_DIR) output -json host_inventory 2>/dev/null | \
+	python3 -c "import sys,json; print(json.load(sys.stdin).get('$(HOST)',{}).get('role',''))" 2>/dev/null))
+
+_resolve_targets = $(eval TARGET_IPS := $(shell terraform -chdir=$(TF_DIR) output -json host_inventory 2>/dev/null | \
+	python3 -c "import sys,json; inv=json.load(sys.stdin); print(','.join(v['private_ip'] for k,v in inv.items() if v.get('role') in ('dhcp_server','domain_controller') and k != '$(HOST)'))" 2>/dev/null))
+
+_map_role = $(if $(filter agent_client,$(HOST_ROLE)),AgentClient,$(if $(filter dhcp_server,$(HOST_ROLE)),DhcpServer,$(if $(filter domain_controller,$(HOST_ROLE)),DomainController,)))
+
+check-prereqs: _require_host _resolve_instance_id
+	$(_resolve_role)
+	$(_resolve_targets)
+	$(eval PS_ROLE := $(call _map_role))
+	@if [ -z "$(PS_ROLE)" ]; then echo "ERROR: Could not determine role for HOST=$(HOST) (role='$(HOST_ROLE)')"; exit 1; fi
+	@echo "=== Checking prerequisites on $(HOST) ($(INSTANCE_ID)) role=$(PS_ROLE) ==="
+	@scripts/run_prereqs_via_ssm.sh \
+		--profile "$(AWS_PROFILE)" --region "$(AWS_REGION)" \
+		--instance-id "$(INSTANCE_ID)" \
+		--role "$(PS_ROLE)" \
+		--script scripts/check-prerequisites.ps1 \
+		$(if $(filter AgentClient,$(PS_ROLE)),--targets "$(TARGET_IPS)" --domain "$(DOMAIN_FQDN)",) \
+		$(if $(filter DomainController DhcpServer,$(PS_ROLE)),--service-user "$(SVC_USER)",)
+
+fix-prereqs: _require_host _resolve_instance_id
+	$(_resolve_role)
+	$(_resolve_targets)
+	$(eval PS_ROLE := $(call _map_role))
+	@if [ -z "$(PS_ROLE)" ]; then echo "ERROR: Could not determine role for HOST=$(HOST) (role='$(HOST_ROLE)')"; exit 1; fi
+	@echo "=== Checking & FIXING prerequisites on $(HOST) ($(INSTANCE_ID)) role=$(PS_ROLE) ==="
+	@scripts/run_prereqs_via_ssm.sh \
+		--profile "$(AWS_PROFILE)" --region "$(AWS_REGION)" \
+		--instance-id "$(INSTANCE_ID)" \
+		--role "$(PS_ROLE)" --fix \
+		--script scripts/check-prerequisites.ps1 \
+		$(if $(filter AgentClient,$(PS_ROLE)),--targets "$(TARGET_IPS)" --domain "$(DOMAIN_FQDN)",) \
+		$(if $(filter DomainController DhcpServer,$(PS_ROLE)),--service-user "$(SVC_USER)",)

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,0 +1,90 @@
+# Prerequisite Testing
+
+Scripts for validating and fixing Infoblox DHCP prerequisites on Windows VMs, executed remotely via AWS SSM.
+
+## Scripts
+
+| Script | Purpose | Customer-safe? |
+|--------|---------|---------------|
+| `check-prerequisites.ps1` | Read-only checker | Yes |
+| `check-prerequisites.ps1 -Fix` | Check + auto-fix | Internal only |
+
+## Make Targets
+
+```bash
+make check-prereqs HOST=name     # read-only check
+make fix-prereqs HOST=name       # check + fix (-Fix flag)
+```
+
+Role, target IPs, domain, and service user are auto-resolved from Terraform output and `environment.yml`.
+
+## Breakable Items by Role
+
+These can be broken ad-hoc via SSM for testing, then fixed with `make fix-prereqs`.
+
+| Item | DC | DHCP | Agent | What it does | PowerShell to break |
+|------|:--:|:----:|:-----:|--------------|---------------------|
+| WinRM | x | x | x | Stops WinRM service | `Stop-Service WinRM -Force; Set-Service -Name WinRM -StartupType Manual` |
+| Firewall | x | x | | Disables WinRM inbound rules | `Get-NetFirewallRule -Name 'WINRM-HTTP-In-TCP*' \| Set-NetFirewallRule -Enabled False` |
+| CredSSP Server | x | x | | Disables CredSSP server role | `Disable-WSManCredSSP -Role Server` |
+| WMI Permissions | x | x | | Removes service user ACE from DHCP WMI namespace | See below |
+| AD Group Membership | x | | | Removes service user from DHCP Admins + Remote Mgmt Users | See below |
+| CredSSP Client | | | x | Disables CredSSP client delegation | `Disable-WSManCredSSP -Role Client` |
+| TrustedHosts | | | x | Clears TrustedHosts list | `Set-Item WSMan:\localhost\Client\TrustedHosts -Value '' -Force` |
+| GPO Delegation | | | x | Removes CredentialsDelegation registry keys | See below |
+
+### WMI Permissions (DC/DHCP)
+
+```powershell
+$ns = 'Root\Microsoft\Windows\DHCP'
+$dp = $env:USERDOMAIN
+if (-not $dp) { $dp = (Get-WmiObject Win32_ComputerSystem).Domain.Split('.')[0].ToUpper() }
+$fa = "$dp\SERVICE_USER"
+$sec = ([wmiclass]"\\localhost\$($ns):__SystemSecurity")
+$sd = $sec.GetSecurityDescriptor().Descriptor
+$newDacl = @()
+foreach ($ace in $sd.DACL) {
+    $name = ''
+    try { $name = (New-Object System.Security.Principal.SecurityIdentifier($ace.Trustee.SIDString)).Translate([System.Security.Principal.NTAccount]).Value } catch {}
+    if ($name -ne $fa) { $newDacl += $ace }
+}
+$sd.DACL = $newDacl
+$sec.SetSecurityDescriptor($sd) | Out-Null
+```
+
+Replace `SERVICE_USER` with the actual service account (e.g. `infoblox_agent`).
+
+### AD Group Membership (DC only)
+
+```powershell
+Import-Module ActiveDirectory
+Remove-ADGroupMember -Identity 'DHCP Administrators' -Members 'SERVICE_USER' -Confirm:$false
+Remove-ADGroupMember -Identity 'Remote Management Users' -Members 'SERVICE_USER' -Confirm:$false
+```
+
+### GPO Delegation (AgentClient only)
+
+```powershell
+$regBase = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation'
+if (Test-Path $regBase) { Remove-Item -Path $regBase -Recurse -Force }
+& gpupdate /force 2>&1 | Out-Null
+```
+
+## Test Workflow
+
+```bash
+# 1. Break something ad-hoc via SSM (or ask the agent to do it)
+# 2. Verify failures
+make check-prereqs HOST=dhcp01
+# 3. Fix
+make fix-prereqs HOST=dhcp01
+# 4. Confirm all green
+make check-prereqs HOST=dhcp01
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `scripts/check-prerequisites.ps1` | Read-only checker with `-Fix` mode |
+| `scripts/run_prereqs_via_ssm.sh` | Sends PowerShell scripts to VMs via SSM send-command |

--- a/scripts/check-prerequisites.ps1
+++ b/scripts/check-prerequisites.ps1
@@ -1,0 +1,617 @@
+<#
+.SYNOPSIS
+    Checks (and optionally fixes) Infoblox DHCP management prerequisites on Windows servers.
+
+.DESCRIPTION
+    Validates the prerequisites documented at:
+    https://docs.infoblox.com/space/UniversalAssetInsights/1835925677/Prerequisites+for+DHCP
+
+    Supports three roles:
+      - DomainController : DC that will be managed by the Infoblox agent
+      - DhcpServer       : Windows DHCP server managed by the Infoblox agent
+      - AgentClient      : Windows member server running the Universal DDI Agent
+
+    When run with -Fix, the script will attempt to remediate any failing checks.
+
+.PARAMETER Role
+    The role of this machine: DomainController, DhcpServer, or AgentClient.
+
+.PARAMETER TargetServers
+    Comma-separated IPs of the DC(s) and DHCP server(s) to manage. Required for AgentClient role.
+
+.PARAMETER DomainFqdn
+    The Active Directory domain FQDN (e.g. corp.local). Required for AgentClient role.
+
+.PARAMETER ServiceUser
+    The AD service account used by the Infoblox agent (e.g. infoblox_agent).
+    Required for DomainController and DhcpServer role checks.
+
+.PARAMETER Fix
+    When specified, attempt to automatically remediate any failing checks.
+
+.EXAMPLE
+    # Check a Domain Controller (read-only)
+    .\check-prerequisites.ps1 -Role DomainController -ServiceUser infoblox_agent
+
+    # Check and fix a DHCP server
+    .\check-prerequisites.ps1 -Role DhcpServer -ServiceUser infoblox_agent -Fix
+
+    # Check and fix the agent client
+    .\check-prerequisites.ps1 -Role AgentClient -TargetServers "10.0.1.10,10.0.1.20" -DomainFqdn corp.local -Fix
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('DomainController', 'DhcpServer', 'AgentClient')]
+    [string]$Role,
+
+    [Parameter()]
+    [string]$TargetServers,
+
+    [Parameter()]
+    [string]$DomainFqdn,
+
+    [Parameter()]
+    [string]$ServiceUser,
+
+    [Parameter()]
+    [switch]$Fix
+)
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+$script:PassCount = 0
+$script:FailCount = 0
+$script:FixedCount = 0
+$script:Errors = @()
+
+function Write-Check {
+    param([string]$Name, [bool]$Passed, [string]$Detail = '')
+    if ($Passed) {
+        $script:PassCount++
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+    } else {
+        $script:FailCount++
+        Write-Host "  [FAIL] $Name" -ForegroundColor Red
+        $script:Errors += "$Name : $Detail"
+    }
+    if ($Detail) { Write-Host "         $Detail" -ForegroundColor Gray }
+}
+
+function Write-Fixed {
+    param([string]$Name)
+    $script:FixedCount++
+    Write-Host "  [FIXED] $Name" -ForegroundColor Yellow
+}
+
+function Write-Section {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host "=== $Title ===" -ForegroundColor Cyan
+}
+
+# ---------------------------------------------------------------------------
+# Validate parameters
+# ---------------------------------------------------------------------------
+if ($Role -eq 'AgentClient') {
+    if (-not $TargetServers) { throw "AgentClient role requires -TargetServers (comma-separated IPs of DCs and DHCP servers)" }
+    if (-not $DomainFqdn)    { throw "AgentClient role requires -DomainFqdn (e.g. corp.local)" }
+}
+if (($Role -eq 'DomainController' -or $Role -eq 'DhcpServer') -and -not $ServiceUser) {
+    throw "$Role role requires -ServiceUser (e.g. infoblox_agent)"
+}
+
+# ---------------------------------------------------------------------------
+# Common: WinRM Service
+# ---------------------------------------------------------------------------
+function Test-WinRMService {
+    Write-Section "WinRM Service"
+
+    $svc = Get-Service -Name WinRM -ErrorAction SilentlyContinue
+    $running = $svc -and $svc.Status -eq 'Running'
+    Write-Check "WinRM service is running" $running "Status: $($svc.Status)"
+
+    if (-not $running -and $Fix) {
+        Set-Service -Name WinRM -StartupType Automatic
+        Start-Service -Name WinRM
+        Write-Fixed "WinRM service started and set to Automatic"
+    }
+
+    # Check PSRemoting listener
+    $listener = $null
+    try { $listener = Get-WSManInstance -ResourceURI winrm/config/listener -Enumerate 2>$null | Where-Object { $_.Transport -eq 'HTTP' } } catch {}
+    $hasListener = $null -ne $listener
+    Write-Check "WinRM HTTP listener configured" $hasListener
+
+    if (-not $hasListener -and $Fix) {
+        Enable-PSRemoting -Force -SkipNetworkProfileCheck
+        Write-Fixed "Enable-PSRemoting executed"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# DC / DHCP Server: CredSSP Server Role
+# ---------------------------------------------------------------------------
+function Test-CredSSPServer {
+    Write-Section "CredSSP Server Role"
+
+    $credSsp = $false
+    try {
+        $out = Get-WSManCredSSP 2>$null
+        $credSsp = ($out | Out-String) -match 'This computer is configured to receive credentials'
+    } catch {}
+    Write-Check "CredSSP server role enabled" $credSsp
+
+    if (-not $credSsp -and $Fix) {
+        Enable-WSManCredSSP -Role Server -Force
+        Write-Fixed "CredSSP server role enabled"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# DC / DHCP Server: WMI Permissions on DHCP namespace
+# ---------------------------------------------------------------------------
+function Test-WmiDhcpPermissions {
+    param([string]$Account)
+
+    Write-Section "WMI Permissions (Root\Microsoft\Windows\DHCP)"
+
+    $ns = 'Root\Microsoft\Windows\DHCP'
+    $hasDhcpNs = $false
+    try {
+        $null = [wmiclass]"\\localhost\$($ns):__SystemSecurity"
+        $hasDhcpNs = $true
+    } catch {}
+
+    if (-not $hasDhcpNs) {
+        Write-Check "DHCP WMI namespace exists" $false "Namespace $ns not found — is DHCP installed?"
+        return
+    }
+    Write-Check "DHCP WMI namespace exists" $true
+
+    # Resolve the account to check — use DOMAIN\user format
+    $domainPrefix = ($env:USERDOMAIN)
+    if (-not $domainPrefix) { $domainPrefix = (Get-WmiObject Win32_ComputerSystem).Domain.Split('.')[0].ToUpper() }
+    $fullAccount = if ($Account -match '\\') { $Account } else { "$domainPrefix\$Account" }
+
+    $sec = ([wmiclass]"\\localhost\$($ns):__SystemSecurity")
+    $sd = $sec.GetSecurityDescriptor().Descriptor
+
+    $requiredMask = 0x23  # Execute Methods (0x01) + Remote Enable (0x20) + Enable Account (0x02) = 0x23
+    $found = $false
+    foreach ($ace in $sd.DACL) {
+        try {
+            $name = (New-Object System.Security.Principal.SecurityIdentifier($ace.Trustee.SIDString)).Translate(
+                [System.Security.Principal.NTAccount]).Value
+            if ($name -eq $fullAccount) {
+                if (($ace.AccessMask -band $requiredMask) -eq $requiredMask) {
+                    $found = $true
+                }
+            }
+        } catch {}
+    }
+    Write-Check "'$fullAccount' has Execute Methods + Remote Enable on DHCP WMI" $found
+
+    if (-not $found -and $Fix) {
+        try {
+            $sid = (New-Object System.Security.Principal.NTAccount($fullAccount)).Translate(
+                [System.Security.Principal.SecurityIdentifier])
+            $ace = ([wmiclass]'Win32_ACE').CreateInstance()
+            $trustee = ([wmiclass]'Win32_Trustee').CreateInstance()
+            $trustee.SIDString = $sid.Value
+            $ace.AccessMask = $requiredMask
+            $ace.AceType = 0  # Allow
+            $ace.AceFlags = 0
+            $ace.Trustee = $trustee
+            $sd.DACL += $ace
+            $sec.SetSecurityDescriptor($sd) | Out-Null
+            Write-Fixed "'$fullAccount' granted Execute Methods + Remote Enable on $ns"
+        } catch {
+            Write-Host "  [ERROR] Could not set WMI permissions for '$fullAccount': $($_.Exception.Message)" -ForegroundColor Red
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# DC: AD Service User & Group Membership
+# ---------------------------------------------------------------------------
+function Test-ADServiceUser {
+    param([string]$User)
+
+    Write-Section "AD Service User ($User)"
+
+    # Check AD module available
+    $adModule = Get-Module -ListAvailable -Name ActiveDirectory
+    if (-not $adModule) {
+        Write-Check "ActiveDirectory PowerShell module available" $false "Install RSAT-AD-PowerShell"
+        return
+    }
+    Import-Module ActiveDirectory -ErrorAction SilentlyContinue
+
+    # Check user exists
+    $adUser = $null
+    try { $adUser = Get-ADUser -Identity $User -Properties MemberOf -ErrorAction Stop } catch {}
+    Write-Check "AD user '$User' exists" ($null -ne $adUser)
+
+    if (-not $adUser) {
+        Write-Host "         Cannot check group membership without the user existing." -ForegroundColor Gray
+        return
+    }
+
+    # Check user is enabled
+    Write-Check "AD user '$User' is enabled" $adUser.Enabled
+
+    # Required groups
+    $requiredGroups = @('DHCP Administrators', 'Remote Management Users')
+    $memberGroups = $adUser.MemberOf | ForEach-Object { ($_ -split ',')[0] -replace 'CN=' }
+
+    foreach ($group in $requiredGroups) {
+        $inGroup = $memberGroups -contains $group
+        Write-Check "User '$User' is member of '$group'" $inGroup
+
+        if (-not $inGroup -and $Fix) {
+            try {
+                Add-ADGroupMember -Identity $group -Members $User -ErrorAction Stop
+                Write-Fixed "Added '$User' to '$group'"
+            } catch {
+                Write-Host "  [ERROR] Could not add to group: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Agent Client: CredSSP Client Role
+# ---------------------------------------------------------------------------
+function Test-CredSSPClient {
+    param([string[]]$Targets)
+
+    Write-Section "CredSSP Client Role"
+
+    $credSspOut = ''
+    try { $credSspOut = (Get-WSManCredSSP 2>$null) | Out-String } catch {}
+
+    $allDelegated = $true
+    foreach ($ip in $Targets) {
+        $delegated = $credSspOut -match [regex]::Escape("wsman/$ip")
+        Write-Check "CredSSP client delegates to $ip" $delegated
+        if (-not $delegated) { $allDelegated = $false }
+    }
+
+    if (-not $allDelegated -and $Fix) {
+        foreach ($ip in $Targets) {
+            if (-not ($credSspOut -match [regex]::Escape("wsman/$ip"))) {
+                Enable-WSManCredSSP -Role Client -DelegateComputer $ip -Force
+                Write-Fixed "CredSSP client delegation added for $ip"
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Agent Client: TrustedHosts
+# ---------------------------------------------------------------------------
+function Test-TrustedHosts {
+    param([string[]]$Targets)
+
+    Write-Section "TrustedHosts"
+
+    $current = (Get-Item WSMan:\localhost\Client\TrustedHosts -ErrorAction SilentlyContinue).Value
+    $currentList = if ($current) { $current.Split(',') | ForEach-Object { $_.Trim() } } else { @() }
+
+    foreach ($ip in $Targets) {
+        $present = $currentList -contains $ip
+        Write-Check "TrustedHosts contains $ip" $present
+    }
+
+    $missing = $Targets | Where-Object { $_ -notin $currentList }
+    if ($missing -and $Fix) {
+        $newList = (($currentList + $missing) | Select-Object -Unique) -join ','
+        Set-Item WSMan:\localhost\Client\TrustedHosts -Value $newList -Force
+        Write-Fixed "TrustedHosts updated to: $newList"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Agent Client: GPO CredSSP Delegation (Registry)
+# ---------------------------------------------------------------------------
+function Test-GPOCredSSPDelegation {
+    param([string[]]$Targets, [string]$Domain)
+
+    Write-Section "GPO: CredSSP Delegation (Allow Fresh Credentials)"
+
+    $regBase = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation'
+    $polPath = "$env:SystemRoot\System32\GroupPolicy\Machine\Registry.pol"
+
+    # Check AllowFreshCredentials policy is enabled
+    $freshEnabled = $false
+    try {
+        $val = Get-ItemProperty -Path $regBase -Name 'AllowFreshCredentials' -ErrorAction Stop
+        $freshEnabled = $val.AllowFreshCredentials -eq 1
+    } catch {}
+    Write-Check "AllowFreshCredentials policy enabled" $freshEnabled
+
+    # Check each target has WSMAN entry
+    $freshPath = "$regBase\AllowFreshCredentials"
+    $freshEntries = @()
+    try {
+        $props = Get-ItemProperty -Path $freshPath -ErrorAction Stop
+        $freshEntries = $props.PSObject.Properties | Where-Object { $_.Value -match '^WSMAN/' } | ForEach-Object { $_.Value }
+    } catch {}
+
+    foreach ($ip in $Targets) {
+        $hasEntry = $freshEntries -contains "WSMAN/$ip"
+        Write-Check "AllowFreshCredentials has WSMAN/$ip" $hasEntry
+    }
+
+    # Check WSMAN/*.<domain> wildcard
+    $wildcard = "WSMAN/*.$Domain"
+    $hasWildcard = $freshEntries -contains $wildcard
+    Write-Check "AllowFreshCredentials has $wildcard" $hasWildcard
+
+    # Check AllowFreshCredentialsWhenNTLMOnly
+    Write-Section "GPO: CredSSP Delegation (Allow Fresh Credentials NTLM-Only)"
+
+    $ntlmEnabled = $false
+    try {
+        $val = Get-ItemProperty -Path $regBase -Name 'AllowFreshCredentialsWhenNTLMOnly' -ErrorAction Stop
+        $ntlmEnabled = $val.AllowFreshCredentialsWhenNTLMOnly -eq 1
+    } catch {}
+    Write-Check "AllowFreshCredentialsWhenNTLMOnly policy enabled" $ntlmEnabled
+
+    $ntlmPath = "$regBase\AllowFreshCredentialsWhenNTLMOnly"
+    $ntlmEntries = @()
+    try {
+        $props = Get-ItemProperty -Path $ntlmPath -ErrorAction Stop
+        $ntlmEntries = $props.PSObject.Properties | Where-Object { $_.Value -match '^WSMAN/' } | ForEach-Object { $_.Value }
+    } catch {}
+
+    foreach ($ip in $Targets) {
+        $hasEntry = $ntlmEntries -contains "WSMAN/$ip"
+        Write-Check "AllowFreshCredentialsWhenNTLMOnly has WSMAN/$ip" $hasEntry
+    }
+
+    $hasNtlmWildcard = $ntlmEntries -contains $wildcard
+    Write-Check "AllowFreshCredentialsWhenNTLMOnly has $wildcard" $hasNtlmWildcard
+
+    # --- Fix via PolicyFileEditor or direct registry ---
+    if ($Fix) {
+        $needsFix = (-not $freshEnabled) -or (-not $ntlmEnabled) -or
+                    ($Targets | Where-Object { "WSMAN/$_" -notin $freshEntries }) -or
+                    ($Targets | Where-Object { "WSMAN/$_" -notin $ntlmEntries }) -or
+                    (-not $hasWildcard) -or (-not $hasNtlmWildcard)
+
+        if ($needsFix) {
+            # Try PolicyFileEditor first (preferred, writes Registry.pol)
+            $hasPFE = $null -ne (Get-Module -ListAvailable -Name PolicyFileEditor)
+            if (-not $hasPFE) {
+                Write-Host "  Installing PolicyFileEditor module..." -ForegroundColor Yellow
+                try {
+                    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+                    Install-Module -Name PolicyFileEditor -Force -Scope AllUsers | Out-Null
+                    $hasPFE = $true
+                } catch {
+                    Write-Host "  [WARN] Could not install PolicyFileEditor, falling back to direct registry" -ForegroundColor Yellow
+                }
+            }
+
+            if ($hasPFE) {
+                Import-Module PolicyFileEditor
+                $regPath = 'SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation'
+
+                # AllowFreshCredentials
+                Set-PolicyFileEntry -Path $polPath -Key $regPath -ValueName 'AllowFreshCredentials' -Data 1 -Type DWord
+                Set-PolicyFileEntry -Path $polPath -Key $regPath -ValueName 'ConcatenateDefaults_AllowFresh' -Data 1 -Type DWord
+                $i = 1
+                foreach ($ip in $Targets) {
+                    Set-PolicyFileEntry -Path $polPath -Key "$regPath\AllowFreshCredentials" -ValueName "$i" -Data "WSMAN/$ip" -Type String
+                    $i++
+                }
+                Set-PolicyFileEntry -Path $polPath -Key "$regPath\AllowFreshCredentials" -ValueName "$i" -Data $wildcard -Type String
+
+                # AllowFreshCredentialsWhenNTLMOnly
+                Set-PolicyFileEntry -Path $polPath -Key $regPath -ValueName 'AllowFreshCredentialsWhenNTLMOnly' -Data 1 -Type DWord
+                Set-PolicyFileEntry -Path $polPath -Key $regPath -ValueName 'ConcatenateDefaults_AllowFreshNTLMOnly' -Data 1 -Type DWord
+                $i = 1
+                foreach ($ip in $Targets) {
+                    Set-PolicyFileEntry -Path $polPath -Key "$regPath\AllowFreshCredentialsWhenNTLMOnly" -ValueName "$i" -Data "WSMAN/$ip" -Type String
+                    $i++
+                }
+                Set-PolicyFileEntry -Path $polPath -Key "$regPath\AllowFreshCredentialsWhenNTLMOnly" -ValueName "$i" -Data $wildcard -Type String
+
+                Write-Fixed "GPO Registry.pol updated with CredSSP delegation entries"
+            } else {
+                # Direct registry fallback
+                if (-not (Test-Path $regBase)) { New-Item -Path $regBase -Force | Out-Null }
+                Set-ItemProperty -Path $regBase -Name 'AllowFreshCredentials' -Value 1 -Type DWord
+                Set-ItemProperty -Path $regBase -Name 'ConcatenateDefaults_AllowFresh' -Value 1 -Type DWord
+                $freshSubPath = "$regBase\AllowFreshCredentials"
+                if (-not (Test-Path $freshSubPath)) { New-Item -Path $freshSubPath -Force | Out-Null }
+                $i = 1
+                foreach ($ip in $Targets) { Set-ItemProperty -Path $freshSubPath -Name "$i" -Value "WSMAN/$ip" -Type String; $i++ }
+                Set-ItemProperty -Path $freshSubPath -Name "$i" -Value $wildcard -Type String
+
+                Set-ItemProperty -Path $regBase -Name 'AllowFreshCredentialsWhenNTLMOnly' -Value 1 -Type DWord
+                Set-ItemProperty -Path $regBase -Name 'ConcatenateDefaults_AllowFreshNTLMOnly' -Value 1 -Type DWord
+                $ntlmSubPath = "$regBase\AllowFreshCredentialsWhenNTLMOnly"
+                if (-not (Test-Path $ntlmSubPath)) { New-Item -Path $ntlmSubPath -Force | Out-Null }
+                $i = 1
+                foreach ($ip in $Targets) { Set-ItemProperty -Path $ntlmSubPath -Name "$i" -Value "WSMAN/$ip" -Type String; $i++ }
+                Set-ItemProperty -Path $ntlmSubPath -Name "$i" -Value $wildcard -Type String
+
+                Write-Fixed "GPO registry entries set directly (Registry.pol not available)"
+            }
+
+            # Apply group policy
+            & gpupdate /force 2>&1 | Out-Null
+            Write-Fixed "Group policy refreshed (gpupdate /force)"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Agent Client: Network connectivity to targets
+# ---------------------------------------------------------------------------
+function Test-NetworkConnectivity {
+    param([string[]]$Targets)
+
+    Write-Section "Network Connectivity (WinRM port 5985)"
+
+    foreach ($ip in $Targets) {
+        $reachable = $false
+        try {
+            $tcp = New-Object System.Net.Sockets.TcpClient
+            $result = $tcp.BeginConnect($ip, 5985, $null, $null)
+            $waited = $result.AsyncWaitHandle.WaitOne(3000, $false)
+            if ($waited -and $tcp.Connected) { $reachable = $true }
+            $tcp.Close()
+        } catch {}
+        Write-Check "TCP connection to ${ip}:5985" $reachable $(if (-not $reachable) { "Cannot connect — check WinRM on target and firewall rules" } else { "" })
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Agent Client: RSAT Features
+# ---------------------------------------------------------------------------
+function Test-RSATFeatures {
+    Write-Section "RSAT Features (Agent Client)"
+
+    $requiredFeatures = @('RSAT-AD-PowerShell', 'RSAT-DNS-Server', 'RSAT-DHCP')
+    foreach ($feature in $requiredFeatures) {
+        $installed = $false
+        try {
+            $f = Get-WindowsFeature -Name $feature -ErrorAction Stop
+            $installed = $f.Installed
+        } catch {}
+        Write-Check "$feature installed" $installed
+
+        if (-not $installed -and $Fix) {
+            try {
+                Install-WindowsFeature -Name $feature -ErrorAction Stop | Out-Null
+                Write-Fixed "$feature installed"
+            } catch {
+                Write-Host "  [ERROR] Could not install ${feature}: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# DC/DHCP: Firewall rules for WinRM
+# ---------------------------------------------------------------------------
+function Test-WinRMFirewall {
+    Write-Section "Firewall: WinRM Inbound"
+
+    $rules = Get-NetFirewallRule -Name 'WINRM-HTTP-In-TCP*' -ErrorAction SilentlyContinue
+    $enabled = $rules | Where-Object { $_.Enabled -eq 'True' }
+    $hasRule = $null -ne $enabled -and ($enabled | Measure-Object).Count -gt 0
+    Write-Check "WinRM HTTP inbound firewall rule enabled" $hasRule
+
+    if (-not $hasRule -and $Fix) {
+        try {
+            Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP-PUBLIC' -RemoteAddress Any -Enabled True -ErrorAction Stop
+            Write-Fixed "WinRM firewall rule enabled for all remote addresses"
+        } catch {
+            try {
+                Enable-PSRemoting -Force -SkipNetworkProfileCheck
+                Write-Fixed "Enable-PSRemoting re-run to create firewall rules"
+            } catch {
+                Write-Host "  [ERROR] Could not configure firewall: $($_.Exception.Message)" -ForegroundColor Red
+            }
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end: PSRemoting test from agent client to targets
+# ---------------------------------------------------------------------------
+function Test-PSRemotingConnectivity {
+    param([string[]]$Targets)
+
+    Write-Section "PSRemoting Connectivity (WinRM + Auth)"
+
+    foreach ($ip in $Targets) {
+        $reachable = $false
+        try {
+            $reachable = Test-WSMan -ComputerName $ip -ErrorAction Stop
+            $reachable = $true
+        } catch {
+            $reachable = $false
+        }
+        Write-Check "WSMan responds on $ip" $reachable $(if (-not $reachable) { "WinRM not reachable — ensure Enable-PSRemoting and CredSSP Server are configured on that host" } else { "" })
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor White
+Write-Host " Infoblox DHCP Prerequisites Checker" -ForegroundColor White
+Write-Host "==========================================" -ForegroundColor White
+Write-Host " Host      : $env:COMPUTERNAME"
+Write-Host " Role      : $Role"
+Write-Host " Fix mode  : $(if ($Fix) { 'ENABLED' } else { 'Disabled (read-only)' })"
+Write-Host " Timestamp : $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
+Write-Host "==========================================" -ForegroundColor White
+
+switch ($Role) {
+    'DomainController' {
+        Test-WinRMService
+        Test-WinRMFirewall
+        Test-CredSSPServer
+        Test-WmiDhcpPermissions -Account $ServiceUser
+        Test-ADServiceUser -User $ServiceUser
+    }
+    'DhcpServer' {
+        Test-WinRMService
+        Test-WinRMFirewall
+        Test-CredSSPServer
+        Test-WmiDhcpPermissions -Account $ServiceUser
+    }
+    'AgentClient' {
+        $targets = $TargetServers.Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        Test-WinRMService
+        Test-RSATFeatures
+        Test-NetworkConnectivity -Targets $targets
+        Test-PSRemotingConnectivity -Targets $targets
+        Test-CredSSPClient -Targets $targets
+        Test-TrustedHosts -Targets $targets
+        Test-GPOCredSSPDelegation -Targets $targets -Domain $DomainFqdn
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor White
+Write-Host " SUMMARY" -ForegroundColor White
+Write-Host "==========================================" -ForegroundColor White
+Write-Host "  Passed : $script:PassCount" -ForegroundColor Green
+Write-Host "  Failed : $script:FailCount" -ForegroundColor $(if ($script:FailCount -gt 0) { 'Red' } else { 'Green' })
+if ($Fix) {
+    Write-Host "  Fixed  : $script:FixedCount" -ForegroundColor Yellow
+}
+Write-Host ""
+
+if ($script:Errors.Count -gt 0 -and -not $Fix) {
+    Write-Host "  Failing checks:" -ForegroundColor Red
+    foreach ($err in $script:Errors) {
+        Write-Host "    - $err" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "  Tip: Re-run with -Fix to attempt automatic remediation." -ForegroundColor Yellow
+    Write-Host ""
+}
+
+if ($script:FailCount -gt 0) {
+    exit 1
+} else {
+    Write-Host "  All prerequisites met." -ForegroundColor Green
+    Write-Host ""
+    exit 0
+}

--- a/scripts/check-prerequisites.ps1
+++ b/scripts/check-prerequisites.ps1
@@ -126,7 +126,7 @@ function Test-WinRMService {
     Write-Check "WinRM HTTP listener configured" $hasListener
 
     if (-not $hasListener -and $Fix) {
-        Enable-PSRemoting -Force -SkipNetworkProfileCheck
+        Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
         Write-Fixed "Enable-PSRemoting executed"
     }
 }
@@ -145,7 +145,7 @@ function Test-CredSSPServer {
     Write-Check "CredSSP server role enabled" $credSsp
 
     if (-not $credSsp -and $Fix) {
-        Enable-WSManCredSSP -Role Server -Force
+        Enable-WSManCredSSP -Role Server -Force | Out-Null
         Write-Fixed "CredSSP server role enabled"
     }
 }
@@ -283,7 +283,7 @@ function Test-CredSSPClient {
     if (-not $allDelegated -and $Fix) {
         foreach ($ip in $Targets) {
             if (-not ($credSspOut -match [regex]::Escape("wsman/$ip"))) {
-                Enable-WSManCredSSP -Role Client -DelegateComputer $ip -Force
+                Enable-WSManCredSSP -Role Client -DelegateComputer $ip -Force | Out-Null
                 Write-Fixed "CredSSP client delegation added for $ip"
             }
         }
@@ -516,7 +516,7 @@ function Test-WinRMFirewall {
             Write-Fixed "WinRM firewall rule enabled for all remote addresses"
         } catch {
             try {
-                Enable-PSRemoting -Force -SkipNetworkProfileCheck
+                Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
                 Write-Fixed "Enable-PSRemoting re-run to create firewall rules"
             } catch {
                 Write-Host "  [ERROR] Could not configure firewall: $($_.Exception.Message)" -ForegroundColor Red

--- a/scripts/check-prerequisites.ps1
+++ b/scripts/check-prerequisites.ps1
@@ -166,12 +166,12 @@ function Test-WmiDhcpPermissions {
     } catch {}
 
     if (-not $hasDhcpNs) {
-        Write-Check "DHCP WMI namespace exists" $false "Namespace $ns not found — is DHCP installed?"
+        Write-Check "DHCP WMI namespace exists" $false "Namespace $ns not found -- is DHCP installed?"
         return
     }
     Write-Check "DHCP WMI namespace exists" $true
 
-    # Resolve the account to check — use DOMAIN\user format
+    # Resolve the account to check -- use DOMAIN\user format
     $domainPrefix = ($env:USERDOMAIN)
     if (-not $domainPrefix) { $domainPrefix = (Get-WmiObject Win32_ComputerSystem).Domain.Split('.')[0].ToUpper() }
     $fullAccount = if ($Account -match '\\') { $Account } else { "$domainPrefix\$Account" }
@@ -469,7 +469,7 @@ function Test-NetworkConnectivity {
             if ($waited -and $tcp.Connected) { $reachable = $true }
             $tcp.Close()
         } catch {}
-        Write-Check "TCP connection to ${ip}:5985" $reachable $(if (-not $reachable) { "Cannot connect — check WinRM on target and firewall rules" } else { "" })
+        Write-Check "TCP connection to ${ip}:5985" $reachable $(if (-not $reachable) { "Cannot connect -- check WinRM on target and firewall rules" } else { "" })
     }
 }
 
@@ -541,7 +541,7 @@ function Test-PSRemotingConnectivity {
         } catch {
             $reachable = $false
         }
-        Write-Check "WSMan responds on $ip" $reachable $(if (-not $reachable) { "WinRM not reachable — ensure Enable-PSRemoting and CredSSP Server are configured on that host" } else { "" })
+        Write-Check "WSMan responds on $ip" $reachable $(if (-not $reachable) { "WinRM not reachable -- ensure Enable-PSRemoting and CredSSP Server are configured on that host" } else { "" })
     }
 }
 

--- a/scripts/run_prereqs_via_ssm.sh
+++ b/scripts/run_prereqs_via_ssm.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Send check-prerequisites.ps1 to a Windows EC2 instance via SSM and stream output.
+# Uses only the AWS CLI (no Python dependencies).
+#
+# Usage (called by Makefile):
+#   scripts/run_prereqs_via_ssm.sh \
+#       --profile my-profile --region us-east-1 \
+#       --instance-id i-0abc123 --role DhcpServer \
+#       --script scripts/check-prerequisites.ps1 [--fix]
+
+set -euo pipefail
+
+# --- Parse arguments ---
+PROFILE="" REGION="" INSTANCE_ID="" ROLE="" SCRIPT="" FIX=""
+TARGETS="" DOMAIN="" SERVICE_USER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)      PROFILE="$2";      shift 2 ;;
+    --region)       REGION="$2";       shift 2 ;;
+    --instance-id)  INSTANCE_ID="$2";  shift 2 ;;
+    --role)         ROLE="$2";         shift 2 ;;
+    --script)       SCRIPT="$2";       shift 2 ;;
+    --fix)          FIX="-Fix";        shift   ;;
+    --targets)      TARGETS="$2";      shift 2 ;;
+    --domain)       DOMAIN="$2";       shift 2 ;;
+    --service-user) SERVICE_USER="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$PROFILE" || -z "$REGION" || -z "$INSTANCE_ID" || -z "$ROLE" || -z "$SCRIPT" ]] && {
+  echo "Missing required arguments" >&2; exit 1
+}
+
+# --- Read the PowerShell script ---
+SCRIPT_BODY=$(<"$SCRIPT")
+
+# --- Build the parameter string for check-prerequisites.ps1 ---
+PS_PARAMS="-Role $ROLE"
+[[ -n "$TARGETS" ]]      && PS_PARAMS="$PS_PARAMS -TargetServers \\\"$TARGETS\\\""
+[[ -n "$DOMAIN" ]]        && PS_PARAMS="$PS_PARAMS -DomainFqdn \\\"$DOMAIN\\\""
+[[ -n "$SERVICE_USER" ]]  && PS_PARAMS="$PS_PARAMS -ServiceUser \\\"$SERVICE_USER\\\""
+[[ -n "$FIX" ]]           && PS_PARAMS="$PS_PARAMS -Fix"
+
+# --- Build a JSON payload file for SSM ---
+# We write the script to a temp file on the remote host, execute it, then clean up.
+TMPJSON=$(mktemp /tmp/ssm-prereqs-XXXXXX.json)
+trap 'rm -f "$TMPJSON"' EXIT
+
+# Use python3 (stdlib only) to safely JSON-encode the script body into the commands array
+python3 -c "
+import json, sys
+
+script_body = sys.stdin.read()
+commands = [
+    '\$ErrorActionPreference = \"Stop\"',
+    '\$scriptPath = \"\$env:TEMP\\\\check-prerequisites.ps1\"',
+    'Set-Content -Path \$scriptPath -Encoding UTF8 -Value @\\'',
+    script_body,
+    '\\'@',
+    '& \$scriptPath $PS_PARAMS'.replace('\$PS_PARAMS', '''$PS_PARAMS'''),
+    '\$exitCode = \$LASTEXITCODE',
+    'Remove-Item -Path \$scriptPath -Force -ErrorAction SilentlyContinue',
+    'exit \$exitCode',
+]
+json.dump({'commands': commands}, sys.stdout)
+" <<< "$SCRIPT_BODY" > "$TMPJSON"
+
+# --- Send command ---
+echo "Sending command to $INSTANCE_ID..."
+COMMAND_ID=$(aws ssm send-command \
+  --profile "$PROFILE" --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters "file://$TMPJSON" \
+  --timeout-seconds 300 \
+  --comment "$([ -n "$FIX" ] && echo fix || echo check)-prereqs ($ROLE)" \
+  --output text --query 'Command.CommandId')
+
+echo "Command ID: $COMMAND_ID"
+echo "Waiting for completion..."
+echo ""
+
+# --- Poll for completion ---
+while true; do
+  sleep 3
+  STATUS=$(aws ssm get-command-invocation \
+    --profile "$PROFILE" --region "$REGION" \
+    --command-id "$COMMAND_ID" \
+    --instance-id "$INSTANCE_ID" \
+    --output text --query 'Status' 2>/dev/null || echo "Pending")
+
+  case "$STATUS" in
+    Success|Failed|Cancelled|TimedOut) break ;;
+    *) printf "." ;;
+  esac
+done
+echo ""
+
+# --- Print output ---
+aws ssm get-command-invocation \
+  --profile "$PROFILE" --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --output text --query 'StandardOutputContent' 2>/dev/null || true
+
+STDERR=$(aws ssm get-command-invocation \
+  --profile "$PROFILE" --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --output text --query 'StandardErrorContent' 2>/dev/null || true)
+
+if [[ -n "$STDERR" && "$STDERR" != "None" ]]; then
+  echo "--- STDERR ---" >&2
+  echo "$STDERR" >&2
+fi
+
+if [[ "$STATUS" != "Success" ]]; then
+  echo "" >&2
+  echo "Command finished with status: $STATUS" >&2
+  exit 1
+else
+  echo "Command finished successfully."
+fi


### PR DESCRIPTION
## Add Infoblox DHCP Prerequisites Checker & Fixer

### Problem

Customers encounter WinRM/CredSSP connectivity errors (e.g. `PSRemotingTransportException CannotConnect`) when the Infoblox agent tries to manage DHCP servers. Diagnosing which prerequisite is missing requires manual checks across multiple machines, referencing the [Prerequisites for DHCP](https://docs.infoblox.com/space/UniversalAssetInsights/1835925677/Prerequisites+for+DHCP) documentation.

### Solution

A self-contained PowerShell script (`scripts/check-prerequisites.ps1`) that validates **all** prerequisites from the Infoblox DHCP doc and can **automatically fix** any failures.

### Supported Roles

| Role | Target Machine |
|------|---------------|
| `DomainController` | Each DC managed by Infoblox |
| `DhcpServer` | Each Windows DHCP server managed by Infoblox |
| `AgentClient` | The Windows member server running the Universal DDI Agent |

### What It Checks (and Fixes)

| Check | DC | DHCP | Agent |
|-------|:--:|:----:|:-----:|
| WinRM service running + HTTP listener | ✅ | ✅ | ✅ |
| WinRM inbound firewall rule | ✅ | ✅ | |
| CredSSP **Server** role enabled | ✅ | ✅ | |
| CredSSP **Client** delegation to targets | | | ✅ |
| WMI permissions (Execute Methods + Remote Enable) for service user on `Root\Microsoft\Windows\DHCP` | ✅ | ✅ | |
| AD service user exists, enabled, and in required groups (DHCP Administrators, Remote Management Users) | ✅ | | |
| TrustedHosts includes all target IPs | | | ✅ |
| GPO: AllowFreshCredentials (Kerberos) with WSMAN entries | | | ✅ |
| GPO: AllowFreshCredentialsWhenNTLMOnly with WSMAN entries | | | ✅ |
| RSAT features (AD-PowerShell, DNS-Server, DHCP) | | | ✅ |
| TCP connectivity to targets on port 5985 | | | ✅ |
| WSMan reachability to targets | | | ✅ |

### How to Run

Copy `scripts/check-prerequisites.ps1` to the target machine and run in an **elevated PowerShell**.

**DHCP Server — read-only check:**
```powershell
.\check-prerequisites.ps1 -Role DhcpServer -ServiceUser infoblox_agent
```

**DHCP Server — check and auto-fix:**
```powershell
.\check-prerequisites.ps1 -Role DhcpServer -ServiceUser infoblox_agent -Fix
```

**Domain Controller — check and auto-fix:**
```powershell
.\check-prerequisites.ps1 -Role DomainController -ServiceUser infoblox_agent -Fix
```

**Agent Client — check and auto-fix:**
```powershell
.\check-prerequisites.ps1 -Role AgentClient `
    -TargetServers "10.0.1.10,10.0.1.20" `
    -DomainFqdn corp.local `
    -Fix
```
> Replace the IPs with the DC and DHCP server IPs. Replace `corp.local` with the customer's AD domain FQDN.

### Parameters

| Parameter | Required For | Description |
|-----------|-------------|-------------|
| `-Role` | All | `DomainController`, `DhcpServer`, or `AgentClient` |
| `-ServiceUser` | DC, DHCP | AD service account name (e.g. `infoblox_agent`) |
| `-TargetServers` | Agent | Comma-separated IPs of DCs and DHCP servers to manage |
| `-DomainFqdn` | Agent | AD domain FQDN (e.g. `corp.local`) |
| `-Fix` | None (optional) | When set, auto-remediate any failing checks |

### Example Output

```
==========================================
 Infoblox DHCP Prerequisites Checker
==========================================
 Host      : DHCP01
 Role      : DhcpServer
 Fix mode  : ENABLED
 Timestamp : 2026-04-24 07:32:23
==========================================

=== WinRM Service ===
  [PASS] WinRM service is running
  [PASS] WinRM HTTP listener configured

=== Firewall: WinRM Inbound ===
  [PASS] WinRM HTTP inbound firewall rule enabled

=== CredSSP Server Role ===
  [FAIL] CredSSP server role enabled
  [FIXED] CredSSP server role enabled

=== WMI Permissions (Root\Microsoft\Windows\DHCP) ===
  [PASS] DHCP WMI namespace exists
  [FAIL] 'CORP\infoblox_agent' has Execute Methods + Remote Enable on DHCP WMI
  [FIXED] 'CORP\infoblox_agent' granted Execute Methods + Remote Enable

==========================================
 SUMMARY
==========================================
  Passed : 4
  Failed : 2
  Fixed  : 2
```

### Testing

Verified by intentionally breaking CredSSP and WMI permissions on a test DHCP server, then running the checker and fixer:

1. Disabled CredSSP Server + removed service user WMI ACE
2. Ran script in read-only mode → **4 PASS, 2 FAIL** ✅
3. Ran script with `-Fix` → both auto-remediated ✅
4. Re-ran in read-only mode → **6 PASS, 0 FAIL** ✅